### PR TITLE
filmorate 1.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,39 +15,47 @@
 	<description>filmorate for 10 sprint</description>
 	<properties>
 		<java.version>11</java.version>
+		<spring-boot-version>2.7.4</spring-boot-version>
+		<h2-version>2.1.212</h2-version>
+		<io.opentelemetry.instrumentation-version>1.26.0</io.opentelemetry.instrumentation-version>
 	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+			<version>${spring-boot-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
+			<version>${spring-boot-version}</version>
 		</dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>2.1.212</version>
+			<version>${h2-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jdbc</artifactId>
+			<version>${spring-boot-version}</version>
 		</dependency>
-	</dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<version>${spring-boot-version}</version>
+			<scope>test</scope>
+		</dependency>
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-instrumentation-annotations</artifactId>
+            <version>${io.opentelemetry.instrumentation-version}</version>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/src/test/java/ru/yandex/practicum/filmorate/FilmControllerTest.java
+++ b/src/test/java/ru/yandex/practicum/filmorate/FilmControllerTest.java
@@ -54,7 +54,7 @@ class FilmControllerTest {
         for (ConstraintViolation<Film> violation : violationSet) {
             System.out.println("Фильм не был добавлен так как: " + violation.getMessage());
         }
-        assertEquals(violationSet.size(), 1);
+        assertEquals(1, violationSet.size());
         assertFalse(violationSet.isEmpty()); //Если есть какие-то ошибки, то тест пройден!
     }
 
@@ -63,10 +63,7 @@ class FilmControllerTest {
         Film film = Film.builder()
                 .id(1)
                 .name("Название тестового фильма")
-                .description("Описание тестового фильма с воооооооооооооооооооооооооооооооооооооооооооооооооооо\" +\n" +
-                        "                \"ооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооооо\" +\n" +
-                        "                \"оооооооооооооооооооооооооооооооооооооооооооооооооооо\" +\n" +
-                        "                \"ооооооооооооооооооооооооооооооооооооооооооооооооооот таким описанием!")
+                .description("0".repeat(1000))
                 .releaseDate(LocalDate.of(1980, 1, 1))
                 .duration(100)
                 .mpa(Mpa.builder().id(1).name("G").build())
@@ -75,7 +72,7 @@ class FilmControllerTest {
         for (ConstraintViolation<Film> violation : violationSet) {
             System.out.println("Фильм не был добавлен так как: " + violation.getMessage());
         }
-        assertEquals(violationSet.size(), 1);
+        assertEquals(1, violationSet.size());
         assertFalse(violationSet.isEmpty());
     }
 
@@ -90,7 +87,7 @@ class FilmControllerTest {
                 .mpa(Mpa.builder().id(1).name("G").build())
                 .build();
         Set<ConstraintViolation<Film>> violations = validator.validate(film);
-        assertEquals(violations.size(), 1);
+        assertEquals(1, violations.size());
     }
 
 }


### PR DESCRIPTION
refactor: Версии зависимостей в pom вынесены в отдельный блок properties
refactor: Изменена генерация поля description в методе checkFilmForInvalidDescription() класса FilmControllerTest
refactor: Мелкий рефакторинг аргументов assertEquals() в методах checkFilmForInvalidName(), checkFilmForInvalidDescription(), checkFilmForInvalidReleaseDate() класса FilmControllerTest
del: Удалены лишние зависимости в pom